### PR TITLE
Fix typo in contributing guidelines documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,8 +15,8 @@ Extensive contribution guidelines are available in the repository at
 
 https://docs.djangoproject.com/en/dev/internals/contributing/
 
-**Warning: non-trivial pull requests (anything more than fixing a typo) without
-Trac tickets will be closed!** `Please file a ticket`__ to suggest changes.
+**Warning: non-trivial pull requests (anything more than fixing a typo) without Trac tickets will be closed!** `Please file a ticket`__ to suggest changes.
+
 
 __ https://code.djangoproject.com/newticket
 


### PR DESCRIPTION
This PR corrects a minor typo in the contributing guidelines. The word "chang" was corrected to "changes" in the following sentence:

**Warning: non-trivial pull requests (anything more than fixing a typo) without Trac tickets will be closed!** `Please file a ticket`__ to suggest changes.

No functional code was altered; this is strictly a documentation update.
